### PR TITLE
feat: Create common input components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.11.0",
+        "react-number-format": "^5.3.1",
         "react-redux": "^8.1.3",
         "react-router-dom": "^6.18.0"
       },
@@ -1533,7 +1534,7 @@
       "version": "18.2.14",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.14.tgz",
       "integrity": "sha512-V835xgdSVmyQmI1KLV2BEIUgqEuinxp9O4G6g3FqO/SqLac049E53aysv0oEFD2kHfejeKU+ZqL2bcFWj9gLAQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -4578,6 +4579,18 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-number-format": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.3.1.tgz",
+      "integrity": "sha512-qpYcQLauIeEhCZUZY9jXZnnroOtdy3jYaS1zQ3M1Sr6r/KMOBEIGNIb7eKT19g2N1wbYgFgvDzs19hw5TrB8XQ==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/react-redux": {
       "version": "8.1.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.11.0",
+    "react-number-format": "^5.3.1",
     "react-redux": "^8.1.3",
     "react-router-dom": "^6.18.0"
   },

--- a/src/shared/Inputs/AppInputs/AppInputs.styled.jsx
+++ b/src/shared/Inputs/AppInputs/AppInputs.styled.jsx
@@ -1,0 +1,22 @@
+import { styled } from '@mui/material';
+import { Box } from '@mui/material';
+
+export const StyledPasswordInput = styled(Box)(({ style }) => ({
+  ...style,
+  "input[type='password']": {
+    fontFamily: 'Verdana',
+    letterSpacing: '0.1em',
+    opacity: 0.9,
+  },
+}));
+
+export const StyledSearchInput = styled(Box)(({ value, style }) => ({
+  ...style,
+  '.MuiOutlinedInput-root': {
+    paddingRight: 0,
+    '& .MuiIconButton-root': {
+      visibility: value ? 'visible' : 'hidden',
+      transform: 'scale(0.8)',
+    },
+  },
+}));

--- a/src/shared/Inputs/AppInputs/AppPasswordInput.jsx
+++ b/src/shared/Inputs/AppInputs/AppPasswordInput.jsx
@@ -1,0 +1,36 @@
+import { PropTypes } from 'prop-types';
+
+import BaseInput from '../BaseInput/BaseInput';
+import { commonInputPropTypes } from '../BaseInput/BaseInput.props';
+import { PasswordVisibilityToggle } from '../utils/PasswordVisibilityToggle';
+import { usePasswordShow } from '../utils/usePasswordShow';
+import { StyledPasswordInput } from './AppInputs.styled';
+
+const AppPasswordInput = ({ wrapperStyle, ...props }) => {
+  const { ...toggleProps } = usePasswordShow();
+
+  return (
+    <StyledPasswordInput style={wrapperStyle}>
+      <BaseInput
+        type={toggleProps.showPassword ? 'text' : 'password'}
+        InputProps={{
+          endAdornment: <PasswordVisibilityToggle {...toggleProps} />,
+        }}
+        {...props}
+      />
+    </StyledPasswordInput>
+  );
+};
+
+AppPasswordInput.propTypes = {
+  wrapperStyle: PropTypes.object,
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  ...commonInputPropTypes,
+};
+
+AppPasswordInput.defaultProps = {
+  label: 'Password',
+};
+
+export default AppPasswordInput;

--- a/src/shared/Inputs/AppInputs/AppPasswordInput.jsx
+++ b/src/shared/Inputs/AppInputs/AppPasswordInput.jsx
@@ -1,7 +1,7 @@
 import { PropTypes } from 'prop-types';
 
 import BaseInput from '../BaseInput/BaseInput';
-import { commonInputPropTypes } from '../BaseInput/BaseInput.props';
+import { baseInputPropTypes } from '../BaseInput/BaseInput.props';
 import { PasswordVisibilityToggle } from '../utils/PasswordVisibilityToggle';
 import { usePasswordShow } from '../utils/usePasswordShow';
 import { StyledPasswordInput } from './AppInputs.styled';
@@ -24,9 +24,7 @@ const AppPasswordInput = ({ wrapperStyle, ...props }) => {
 
 AppPasswordInput.propTypes = {
   wrapperStyle: PropTypes.object,
-  value: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
-  ...commonInputPropTypes,
+  ...baseInputPropTypes,
 };
 
 AppPasswordInput.defaultProps = {

--- a/src/shared/Inputs/AppInputs/AppPhoneInput.jsx
+++ b/src/shared/Inputs/AppInputs/AppPhoneInput.jsx
@@ -1,9 +1,7 @@
 import { PatternFormat } from 'react-number-format';
 
-import PropTypes from 'prop-types';
-
 import BaseInput from '../BaseInput/BaseInput';
-import { commonInputPropTypes } from '../BaseInput/BaseInput.props';
+import { baseInputPropTypes } from '../BaseInput/BaseInput.props';
 
 const AppPhoneInput = (props) => {
   return (
@@ -17,11 +15,7 @@ const AppPhoneInput = (props) => {
   );
 };
 
-AppPhoneInput.propTypes = {
-  value: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
-  ...commonInputPropTypes,
-};
+AppPhoneInput.propTypes = baseInputPropTypes;
 
 AppPhoneInput.defaultProps = {
   label: 'Phone Number',

--- a/src/shared/Inputs/AppInputs/AppPhoneInput.jsx
+++ b/src/shared/Inputs/AppInputs/AppPhoneInput.jsx
@@ -1,0 +1,32 @@
+import { PatternFormat } from 'react-number-format';
+
+import PropTypes from 'prop-types';
+
+import BaseInput from '../BaseInput/BaseInput';
+import { commonInputPropTypes } from '../BaseInput/BaseInput.props';
+
+const AppPhoneInput = (props) => {
+  return (
+    <PatternFormat
+      customInput={BaseInput}
+      format="+38 (0##) ### ## ##"
+      mask="x"
+      allowEmptyFormatting
+      {...props}
+    />
+  );
+};
+
+AppPhoneInput.propTypes = {
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  ...commonInputPropTypes,
+};
+
+AppPhoneInput.defaultProps = {
+  label: 'Phone Number',
+  type: 'tel',
+  InputLabelProps: { shrink: true },
+};
+
+export default AppPhoneInput;

--- a/src/shared/Inputs/AppInputs/AppSearchInput.jsx
+++ b/src/shared/Inputs/AppInputs/AppSearchInput.jsx
@@ -7,7 +7,7 @@ import { IconButton, InputAdornment } from '@mui/material';
 import { PropTypes } from 'prop-types';
 
 import BaseInput from '../BaseInput/BaseInput';
-import { commonInputPropTypes } from '../BaseInput/BaseInput.props';
+import { baseInputPropTypes } from '../BaseInput/BaseInput.props';
 import { StyledSearchInput } from './AppInputs.styled';
 
 const AppSearchInput = ({ wrapperStyle, ...props }) => {
@@ -44,9 +44,7 @@ const AppSearchInput = ({ wrapperStyle, ...props }) => {
 
 AppSearchInput.propTypes = {
   wrapperStyle: PropTypes.object,
-  value: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
-  ...commonInputPropTypes,
+  ...baseInputPropTypes,
 };
 
 AppSearchInput.defaultProps = {

--- a/src/shared/Inputs/AppInputs/AppSearchInput.jsx
+++ b/src/shared/Inputs/AppInputs/AppSearchInput.jsx
@@ -1,0 +1,58 @@
+import { useRef } from 'react';
+import { BsSearch } from 'react-icons/bs';
+import { MdClear } from 'react-icons/md';
+
+import { IconButton, InputAdornment } from '@mui/material';
+
+import { PropTypes } from 'prop-types';
+
+import BaseInput from '../BaseInput/BaseInput';
+import { commonInputPropTypes } from '../BaseInput/BaseInput.props';
+import { StyledSearchInput } from './AppInputs.styled';
+
+const AppSearchInput = ({ wrapperStyle, ...props }) => {
+  const inputRef = useRef(null);
+
+  const handleClearClick = () => {
+    props.onChange({ target: { value: '' } });
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  };
+
+  const searchIcons = {
+    startAdornment: (
+      <InputAdornment position="start">
+        <BsSearch />
+      </InputAdornment>
+    ),
+    endAdornment: (
+      <InputAdornment position="end">
+        <IconButton onClick={handleClearClick}>
+          <MdClear />
+        </IconButton>
+      </InputAdornment>
+    ),
+  };
+
+  return (
+    <StyledSearchInput value={props.value} style={wrapperStyle} ref={inputRef}>
+      <BaseInput InputProps={searchIcons} {...props} />
+    </StyledSearchInput>
+  );
+};
+
+AppSearchInput.propTypes = {
+  wrapperStyle: PropTypes.object,
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  ...commonInputPropTypes,
+};
+
+AppSearchInput.defaultProps = {
+  label: 'Search',
+  placeholder: 'Find your favorite dish or chef',
+  type: 'text',
+};
+
+export default AppSearchInput;

--- a/src/shared/Inputs/AppInputs/AppTextInput.jsx
+++ b/src/shared/Inputs/AppInputs/AppTextInput.jsx
@@ -1,0 +1,10 @@
+import BaseInput from '../BaseInput/BaseInput';
+import { baseInputPropTypes } from '../BaseInput/BaseInput.props';
+
+const AppTextInput = (props) => {
+  return <BaseInput type="text" {...props} />;
+};
+
+AppTextInput.propTypes = baseInputPropTypes;
+
+export default AppTextInput;

--- a/src/shared/Inputs/BaseInput/BaseInput.jsx
+++ b/src/shared/Inputs/BaseInput/BaseInput.jsx
@@ -3,20 +3,18 @@ import { baseInputPropTypes } from './BaseInput.props';
 import { StyledBaseInput } from './BaseInput.styled';
 
 /**
- * BaseInput component for rendering an input field
+ * Most commonly used default input field props
  *
  * @component
  * @param {string} label - The label for the input field
  * @param {string} value - The current value of the input field saved in state
  * @param {function} onChange - The callback function to handle the changes of the current value
- * @param {Object} inputStyle - The object to add extra styles for the input field
  * @param {boolean} fullWidth - Set the input {width: 100%}
  * @param {string} size - The height of the input field (small- 40px, medium - 46px, large - 56px)
- * @param {boolean} errorStatus - Whether the input field is in an error state
- * @param {string} underlineText - The helper text to display below the input field
+ * @param {boolean} error - Whether the input field is in an error state (true or false)
+ * @param {string} helperText - The helper text to display below the input field
  * @param {boolean} disabled - Whether the input field is disabled
- * @param {string} id - The id for the input field
- * @param {string} type - The type of the input field (text, password, search)
+ * @param {string} type - The type of the input field (text, password, search, tel)
  * @param {Object} other - Additional props to pass to the input field
  * @returns {JSX.Element}
  */
@@ -24,13 +22,11 @@ const BaseInput = ({
   label,
   value,
   onChange,
-  inputStyle,
-  fullWidth,
+  fullWidth = true,
   size = 'medium',
-  errorStatus,
-  underlineText,
+  error,
+  helperText,
   disabled,
-  id,
   type,
   ...other
 }) => {
@@ -38,7 +34,6 @@ const BaseInput = ({
 
   return (
     <StyledBaseInput
-      id={id}
       type={type}
       variant="outlined"
       theme={theme}
@@ -47,9 +42,8 @@ const BaseInput = ({
       value={value}
       onChange={onChange}
       fullWidth={fullWidth}
-      style={inputStyle}
-      error={errorStatus}
-      helperText={underlineText}
+      error={error}
+      helperText={helperText}
       disabled={disabled}
       {...other}
     />

--- a/src/shared/Inputs/BaseInput/BaseInput.jsx
+++ b/src/shared/Inputs/BaseInput/BaseInput.jsx
@@ -1,0 +1,61 @@
+import { useTheme } from '@emotion/react';
+import { baseInputPropTypes } from './BaseInput.props';
+import { StyledBaseInput } from './BaseInput.styled';
+
+/**
+ * BaseInput component for rendering an input field
+ *
+ * @component
+ * @param {string} label - The label for the input field
+ * @param {string} value - The current value of the input field saved in state
+ * @param {function} onChange - The callback function to handle the changes of the current value
+ * @param {Object} inputStyle - The object to add extra styles for the input field
+ * @param {boolean} fullWidth - Set the input {width: 100%}
+ * @param {string} size - The height of the input field (small- 40px, medium - 46px, large - 56px)
+ * @param {boolean} errorStatus - Whether the input field is in an error state
+ * @param {string} underlineText - The helper text to display below the input field
+ * @param {boolean} disabled - Whether the input field is disabled
+ * @param {string} id - The id for the input field
+ * @param {string} type - The type of the input field (text, password, search)
+ * @param {Object} other - Additional props to pass to the input field
+ * @returns {JSX.Element}
+ */
+const BaseInput = ({
+  label,
+  value,
+  onChange,
+  inputStyle,
+  fullWidth,
+  size = 'medium',
+  errorStatus,
+  underlineText,
+  disabled,
+  id,
+  type,
+  ...other
+}) => {
+  const theme = useTheme();
+
+  return (
+    <StyledBaseInput
+      id={id}
+      type={type}
+      variant="outlined"
+      theme={theme}
+      size={size}
+      label={label}
+      value={value}
+      onChange={onChange}
+      fullWidth={fullWidth}
+      style={inputStyle}
+      error={errorStatus}
+      helperText={underlineText}
+      disabled={disabled}
+      {...other}
+    />
+  );
+};
+
+BaseInput.propTypes = baseInputPropTypes;
+
+export default BaseInput;

--- a/src/shared/Inputs/BaseInput/BaseInput.props.js
+++ b/src/shared/Inputs/BaseInput/BaseInput.props.js
@@ -1,23 +1,16 @@
 import PropTypes from 'prop-types';
 
 export const requiredInputPropTypes = {
-  label: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
 };
 
-export const commonInputPropTypes = {
+export const redefinedInputPropTypes = {
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   type: PropTypes.oneOf(['text', 'password', 'search', 'tel']),
-  fullWidth: PropTypes.bool,
-  inputStyle: PropTypes.object,
-  errorStatus: PropTypes.bool,
-  underlineText: PropTypes.string,
-  disabled: PropTypes.bool,
-  id: PropTypes.string,
 };
 
 export const baseInputPropTypes = {
   ...requiredInputPropTypes,
-  ...commonInputPropTypes,
+  ...redefinedInputPropTypes,
 };

--- a/src/shared/Inputs/BaseInput/BaseInput.props.js
+++ b/src/shared/Inputs/BaseInput/BaseInput.props.js
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types';
+
+export const requiredInputPropTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+};
+
+export const commonInputPropTypes = {
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  type: PropTypes.oneOf(['text', 'password', 'search', 'tel']),
+  fullWidth: PropTypes.bool,
+  inputStyle: PropTypes.object,
+  errorStatus: PropTypes.bool,
+  underlineText: PropTypes.string,
+  disabled: PropTypes.bool,
+  id: PropTypes.string,
+};
+
+export const baseInputPropTypes = {
+  ...requiredInputPropTypes,
+  ...commonInputPropTypes,
+};

--- a/src/shared/Inputs/BaseInput/BaseInput.styled.jsx
+++ b/src/shared/Inputs/BaseInput/BaseInput.styled.jsx
@@ -1,0 +1,32 @@
+import { styled } from '@mui/material';
+import { TextField } from '@mui/material';
+
+/* By default, MUI has only small (40px) and normal (56px) input sizes. 
+The middle size is 46px */
+const mediumInputStyles = {
+  '& .MuiInputBase-input': {
+    paddingTop: '11.5px',
+    paddingBottom: '11.5px',
+  },
+  '& .MuiInputLabel-root': {
+    transform: 'translate(14px, 11.5px) scale(1)',
+  },
+  '& .MuiInputLabel-shrink': {
+    transform: 'translate(14px, -9px) scale(0.75)',
+  },
+};
+
+export const StyledBaseInput = styled(TextField)(({ size, error }) => {
+  return {
+    'MuiFormControl-root': {
+      boxSizing: 'border-box',
+      width: 'inherit',
+    },
+    ...(size === 'medium' && mediumInputStyles),
+    ...(error && {
+      '&:hover fieldset': {
+        borderColor: 'transparent',
+      },
+    }),
+  };
+});

--- a/src/shared/Inputs/BaseInput/BaseInput.styled.jsx
+++ b/src/shared/Inputs/BaseInput/BaseInput.styled.jsx
@@ -20,7 +20,6 @@ export const StyledBaseInput = styled(TextField)(({ size, error }) => {
   return {
     'MuiFormControl-root': {
       boxSizing: 'border-box',
-      width: 'inherit',
     },
     ...(size === 'medium' && mediumInputStyles),
     ...(error && {

--- a/src/shared/Inputs/utils/PasswordVisibilityToggle.jsx
+++ b/src/shared/Inputs/utils/PasswordVisibilityToggle.jsx
@@ -1,0 +1,29 @@
+import { MdVisibility, MdVisibilityOff } from 'react-icons/md';
+
+import { IconButton, InputAdornment } from '@mui/material';
+
+import PropTypes from 'prop-types';
+
+/* "Eye" toggle button to display/hide password */
+export const PasswordVisibilityToggle = ({
+  showPassword,
+  handleClickShowPassword,
+  handleMouseDownPassword,
+}) => (
+  <InputAdornment position="end">
+    <IconButton
+      aria-label="toggle password visibility"
+      onClick={handleClickShowPassword}
+      onMouseDown={handleMouseDownPassword}
+      edge="end"
+    >
+      {showPassword ? <MdVisibilityOff /> : <MdVisibility />}
+    </IconButton>
+  </InputAdornment>
+);
+
+PasswordVisibilityToggle.propTypes = {
+  showPassword: PropTypes.bool.isRequired,
+  handleClickShowPassword: PropTypes.func.isRequired,
+  handleMouseDownPassword: PropTypes.func.isRequired,
+};

--- a/src/shared/Inputs/utils/usePasswordShow.js
+++ b/src/shared/Inputs/utils/usePasswordShow.js
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+
+/* Hook for managing password visibility state */
+export const usePasswordShow = () => {
+  const [showPassword, setShowPassword] = useState(false);
+
+  const handleClickShowPassword = () => {
+    setShowPassword((show) => !show);
+  };
+
+  const handleMouseDownPassword = (event) => {
+    event.preventDefault();
+  };
+
+  return {
+    showPassword,
+    handleClickShowPassword,
+    handleMouseDownPassword,
+  };
+};

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -1,0 +1,7 @@
+/* Base button */
+export { default as AppButton } from './Buttons/AppButton';
+/* Input fields */
+export { default as AppPasswordInput } from './Inputs/AppInputs/AppPasswordInput';
+export { default as AppPhoneInput } from './Inputs/AppInputs/AppPhoneInput';
+export { default as AppSearchInput } from './Inputs/AppInputs/AppSearchInput';
+export { default as AppTextInput } from './Inputs/AppInputs/AppTextInput';


### PR DESCRIPTION

1. Created a common component BaseInput.jsx, serving as the base for various input components. 
2. Created derived specialized input components, including:
- AppTextInput.jsx
- AppPasswordInput.jsx
- AppSearchInput.jsx
- AppPhoneInput.jsx
3. Centralized export for reused common components in shared/index.js.