### PR TITLE
feat: Create common select and autocomplete components

### DIFF
--- a/src/shared/Inputs/BaseInput/BaseInput.styled.jsx
+++ b/src/shared/Inputs/BaseInput/BaseInput.styled.jsx
@@ -3,7 +3,7 @@ import { TextField } from '@mui/material';
 
 /* By default, MUI has only small (40px) and normal (56px) input sizes. 
 The middle size is 46px */
-const mediumInputStyles = {
+export const mediumInputStyles = {
   '& .MuiInputBase-input': {
     paddingTop: '11.5px',
     paddingBottom: '11.5px',

--- a/src/shared/Selects/Autocomplete/AppAutocomplete.jsx
+++ b/src/shared/Selects/Autocomplete/AppAutocomplete.jsx
@@ -1,0 +1,117 @@
+import { useAutocomplete } from '@mui/base/useAutocomplete';
+import CheckIcon from '@mui/icons-material/Check';
+import { FormHelperText } from '@mui/material';
+
+import { autocompletePropTypes } from './AppAutocomplete.props';
+import {
+  AutocompleteWrapper,
+  InputWrapper,
+  Label,
+  Listbox,
+} from './AppAutocomplete.styled';
+import { StyledTag } from './utils/AutocompleteTag.styled';
+
+/**
+ * AppAutocomplete Component
+ *
+ * This component provides an autocomplete input for selecting multiple options from a list.
+ *
+ * @component
+ * @param {Object} props - The component props.
+ * @param {string} props.label - The text label for the autocomplete input.
+ * @param {string[]} props.options - The array of options for the autocomplete.
+ * @param {function} props.onChange - The callback function triggered when the selected options change and add it to the state array.
+ * @param {boolean} [props.error] - Indicates whether there is an error in the input.
+ * @param {string} props.helperText - Additional text to be displayed underneath the input.
+ * @param {string} [props.placeholder] - The placeholder for the autocomplete.
+ * @param {string} [props.id] - The id of the autocomplete input.
+ * @param {Object} [props.style] - The inline style object to apply to the autocomplete wrapper.
+ * @returns {React.Component} The rendered AppAutocomplete component.
+ */
+
+const AppAutocomplete = ({
+  label,
+  options,
+  onChange,
+  error,
+  helperText,
+  placeholder,
+  id,
+  style,
+}) => {
+  const {
+    getRootProps,
+    getInputLabelProps,
+    getInputProps,
+    getTagProps,
+    getListboxProps,
+    getOptionProps,
+    dirty,
+    groupedOptions,
+    value,
+    focused,
+    setAnchorEl,
+  } = useAutocomplete({
+    id,
+    defaultValue: [],
+    multiple: true,
+    options,
+    getOptionLabel: (option) => option,
+    onChange: (_, newValue) => onChange(newValue),
+    disableCloseOnSelect: true,
+  });
+
+  const renderOptions = () => (
+    <Listbox {...getListboxProps()}>
+      {groupedOptions.map((option, index) => (
+        <li {...getOptionProps({ option, index })} key={option}>
+          <span>{option}</span>
+          <CheckIcon fontSize="small" />
+        </li>
+      ))}
+    </Listbox>
+  );
+
+  const renderInputField = () => (
+    <InputWrapper
+      ref={setAnchorEl}
+      className={focused ? 'focused' : ''}
+      error={error}
+    >
+      {value.map((option, index) => (
+        <StyledTag label={option} key={option} {...getTagProps({ index })} />
+      ))}
+      <input {...getInputProps()} placeholder={dirty ? '' : placeholder} />
+    </InputWrapper>
+  );
+
+  return (
+    <AutocompleteWrapper style={style}>
+      <div {...getRootProps()}>
+        {/* Label of input */}
+        {label && <Label {...getInputLabelProps()}>{label}</Label>}
+
+        {/* Input field */}
+        {renderInputField()}
+
+        {/* Underline warning */}
+        {helperText && (
+          <FormHelperText error={error}>{helperText}</FormHelperText>
+        )}
+      </div>
+
+      {/* Options menu */}
+      {groupedOptions.length > 0 && renderOptions()}
+    </AutocompleteWrapper>
+  );
+};
+
+AppAutocomplete.propTypes = autocompletePropTypes;
+
+AppAutocomplete.defaultProps = {
+  id: 'ingredients-autocomplete',
+  error: false,
+  placeholder: 'Select ingredients',
+};
+
+export default AppAutocomplete;

--- a/src/shared/Selects/Autocomplete/AppAutocomplete.props.jsx
+++ b/src/shared/Selects/Autocomplete/AppAutocomplete.props.jsx
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types';
+
+export const autocompletePropTypes = {
+  label: PropTypes.string,
+  options: PropTypes.arrayOf(PropTypes.string).isRequired,
+  onChange: PropTypes.func.isRequired,
+  error: PropTypes.bool,
+  helperText: PropTypes.string,
+  placeholder: PropTypes.string,
+  id: PropTypes.string,
+  style: PropTypes.object,
+};

--- a/src/shared/Selects/Autocomplete/AppAutocomplete.styled.jsx
+++ b/src/shared/Selects/Autocomplete/AppAutocomplete.styled.jsx
@@ -1,0 +1,117 @@
+import { autocompleteClasses } from '@mui/material/Autocomplete';
+import { lighten, styled } from '@mui/material/styles';
+
+export const AutocompleteWrapper = styled('div')(
+  ({ theme }) => `
+  color: ${theme.palette.text.primary};
+  font-size: 14px;
+
+  & .MuiFormHelperText-root {
+    padding: 0 14px;
+  }
+`
+);
+
+export const Label = styled('label')`
+  padding: 0 8px 4px;
+  line-height: 1;
+  display: block;
+`;
+
+export const InputWrapper = styled('div')(({ theme, error }) => {
+  const borderColor = error
+    ? theme.palette.error.main
+    : theme.palette.primary.main;
+
+  return `
+  width: 100%;
+  border: 1px solid ${error ? theme.palette.error.main : '#d9d9d9'};
+  border-radius: 4px;
+  min-height: 46px;
+  display: flex;
+  flex-wrap: wrap;
+  padding: 4px 8px;
+  align-items: center;
+  background-color: ${theme.palette.background.paper};
+  gap: 4px;
+
+  &:hover {
+    border-color: ${borderColor};
+  }
+
+  &.focused {
+    outline: 1px solid ${borderColor};
+    border-color: ${borderColor};
+  }
+
+  
+
+  & input {
+    color: ${theme.palette.secondary.main};
+    height: 30px;
+    font-size: 16px;
+    font-family: ${theme.typography.fontFamily};
+    box-sizing: border-box;
+    padding: 4px 6px;
+    width: 0;
+    min-width: 30px;
+    flex-grow: 1;
+
+    border: 0;
+    margin: 0;
+    outline: 0;
+
+    &::placeholder {
+      font-size: 16px;
+    }
+  }
+`;
+});
+
+export const Listbox = styled('ul')(
+  ({ theme }) => `
+  width: 300px;
+  margin: 2px 0 0;
+  padding: 0;
+  position: absolute;
+  list-style: none;
+  background-color: ${theme.palette.background.paper};
+  overflow: auto;
+  max-height: 250px;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  z-index: 3;
+
+  & li {
+    padding: 5px 12px;
+    display: flex;
+    font-size: 16px;
+
+    & span {
+      flex-grow: 1;
+    }
+
+    & svg {
+      color: transparent;
+    }
+  }
+
+  & li[aria-selected='true'] {
+    background-color: ${theme.palette.background.paper};
+    font-weight: 600;
+
+    & svg {
+        color: ${theme.palette.primary.main};
+    }
+  }
+
+  & li.${autocompleteClasses.focused} {
+    background-color: ${lighten(theme.palette.primary.light, 0.2)};
+    cursor: pointer;
+
+    & svg {
+        color: ${theme.palette.text.secondary};
+    }
+  }
+`
+);

--- a/src/shared/Selects/Autocomplete/utils/AutocompleteTag.styled.jsx
+++ b/src/shared/Selects/Autocomplete/utils/AutocompleteTag.styled.jsx
@@ -1,0 +1,51 @@
+import CloseIcon from '@mui/icons-material/Close';
+import { lighten, styled } from '@mui/material/styles';
+
+import PropTypes from 'prop-types';
+
+const Tag = (props) => {
+  const { label, onDelete, ...other } = props;
+  return (
+    <div {...other}>
+      <span>{label}</span>
+      <CloseIcon onClick={onDelete} />
+    </div>
+  );
+};
+
+Tag.propTypes = {
+  label: PropTypes.string.isRequired,
+  onDelete: PropTypes.func.isRequired,
+};
+
+export const StyledTag = styled(Tag)(
+  ({ theme }) => `
+  display: flex;
+  align-items: center;
+  height: 28px;
+  line-height: 20px;
+  background-color: ${lighten(theme.palette.primary.light, 0.2)};
+  border: 1px solid ${lighten(theme.palette.primary.light, 0.1)};
+  border-radius: 2px;
+  box-sizing: content-box;
+  padding: 0 4px 0 10px;
+  outline: 0;
+  overflow: hidden;
+
+  &:focus {
+    background-color: ${theme.palette.primary.light};
+  }
+
+  & span {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  & svg {
+    font-size: 12px;
+    cursor: pointer;
+    padding: 4px;
+  }
+`
+);

--- a/src/shared/Selects/BasicSelect/AppSelect.jsx
+++ b/src/shared/Selects/BasicSelect/AppSelect.jsx
@@ -1,0 +1,75 @@
+import { FormHelperText, InputLabel, Select } from '@mui/material';
+
+import { useTheme } from '@emotion/react';
+import { basicSelectPropTypes } from './AppSelect.props';
+import { StyledFormControl } from './AppSelect.styles';
+import { renderOptions, renderPlaceholder } from './utils/selectHelpers';
+
+/**
+ * AppSelect Component
+ *
+ * This component provides a basic select input for choosing a single option from a list.
+ *
+ * @component
+ * @param {Object} props - The component props.
+ * @param {string} props.label - The label for the select input.
+ * @param {string} props.value - The currently selected value.
+ * @param {function} props.onChange - The callback function triggered when the selected value changes.
+ * @param {(string[]|Object[])} props.options - The array of options for the select input. Each option can be a string or an object with 'label' and 'value' properties.
+ * @param {boolean} [props.error] - Indicates whether the select input has an error.
+ * @param {string} props.helperText - The helper text to display below the select input.
+ * @param {string} [props.placeholder] - The placeholder for the select input.
+ * @returns {React.Component} The rendered AppSelect component.
+ */
+
+const AppSelect = ({
+  label,
+  value,
+  onChange,
+  options,
+  error,
+  helperText,
+  placeholder,
+}) => {
+  const theme = useTheme();
+
+  return (
+    <StyledFormControl
+      fullWidth
+      error={error}
+      placeholder={placeholder}
+      value={value}
+      size="medium"
+    >
+      <InputLabel
+        id="basic-select-label"
+        shrink={!!value || (placeholder && value === '')}
+      >
+        {label}
+      </InputLabel>
+      <Select
+        labelId="basic-select-label"
+        id="app-basic-select"
+        displayEmpty
+        value={value}
+        label={label}
+        MenuProps={{
+          autoFocus: false,
+        }}
+        onChange={onChange}
+      >
+        {placeholder && renderPlaceholder(placeholder)}
+        {renderOptions(options, theme)}
+      </Select>
+      {helperText && <FormHelperText>{helperText}</FormHelperText>}
+    </StyledFormControl>
+  );
+};
+
+AppSelect.propTypes = basicSelectPropTypes;
+
+AppSelect.defaultProps = {
+  error: false,
+};
+
+export default AppSelect;

--- a/src/shared/Selects/BasicSelect/AppSelect.props.jsx
+++ b/src/shared/Selects/BasicSelect/AppSelect.props.jsx
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+
+const valueTypes = PropTypes.oneOfType([PropTypes.string, PropTypes.number]);
+
+const optionShape = PropTypes.exact({
+  value: valueTypes.isRequired,
+  label: PropTypes.node.isRequired,
+});
+
+const optionTypes = PropTypes.oneOfType([
+  PropTypes.arrayOf(PropTypes.string),
+  PropTypes.arrayOf(PropTypes.number),
+  PropTypes.arrayOf(optionShape),
+]);
+
+export const basicSelectPropTypes = {
+  label: PropTypes.string,
+  value: valueTypes.isRequired,
+  onChange: PropTypes.func.isRequired,
+  options: optionTypes.isRequired,
+  error: PropTypes.bool,
+  helperText: PropTypes.string,
+  placeholder: PropTypes.string,
+};

--- a/src/shared/Selects/BasicSelect/AppSelect.styles.jsx
+++ b/src/shared/Selects/BasicSelect/AppSelect.styles.jsx
@@ -1,0 +1,53 @@
+import { FormControl, MenuItem } from '@mui/material';
+import { lighten, styled } from '@mui/material/styles';
+
+export const StyledMenuItem = styled(MenuItem)(
+  ({ theme }) => `
+    &li.MuiMenuItem-root {
+        height: 30px;
+    }
+    &.MuiMenuItem-root:hover {
+      background-color: ${lighten(theme.palette.primary.light, 0.5)};
+    }
+    & .MuiTouchRipple-root span {
+      background-color: ${theme.palette.primary.light};
+    }
+    &.Mui-selected,
+    &.Mui-selected:hover {
+      background-color: ${theme.palette.primary.light};
+    }
+  `
+);
+
+export const StyledFormControl = styled(FormControl)(
+  ({ theme, placeholder, value }) => `
+    && .MuiSelect-select.MuiSelect-outlined {
+      background-color: ${theme.palette.background.paper};
+    }
+    &&.MuiFormControl-root .MuiInputLabel-root[data-shrink="false"] {
+      transform: translate(14px, 11px) scale(1);
+    }
+    && .MuiOutlinedInput-root.Mui-error .MuiOutlinedInput-notchedOutline {
+      border-color: ${theme.palette.error.main};
+    }
+    & MuiMenuItem-root.Mui-disabled.Mui-selected {
+background-color: ${theme.palette.background.paper};
+    }
+  
+    ${
+      placeholder &&
+      `&.MuiFormControl-root legend {
+        max-width: 100%;
+      }
+      `
+    }
+
+    ${
+      !value &&
+      placeholder &&
+      `& .MuiOutlinedInput-root{
+        color: ${theme.palette.text.secondary}
+      }`
+    }
+  `
+);

--- a/src/shared/Selects/BasicSelect/utils/selectHelpers.jsx
+++ b/src/shared/Selects/BasicSelect/utils/selectHelpers.jsx
@@ -1,0 +1,37 @@
+import { MenuItem } from '@mui/material';
+
+import { StyledMenuItem } from '../AppSelect.styles';
+
+export const renderPlaceholder = (placeholder) => {
+  return (
+    <MenuItem value="" disabled style={{ backgroundColor: 'transparent' }}>
+      {placeholder}
+    </MenuItem>
+  );
+};
+
+/**
+ * Gets the label and value from the given option.
+ *
+ * @param {(string|Object)} option - The option to extract label and value from.
+ * @returns {Object} An object containing 'label' and 'value'.
+ */
+const getOptionData = (option) => {
+  if (typeof option === 'object') {
+    const { label, value } = option;
+    return { label, value };
+  } else {
+    return { label: option, value: option };
+  }
+};
+
+export const renderOptions = (options, theme) => {
+  return options.map((option) => {
+    const { label, value } = getOptionData(option);
+    return (
+      <StyledMenuItem theme={theme} key={value} value={value}>
+        {label}
+      </StyledMenuItem>
+    );
+  });
+};

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -5,3 +5,6 @@ export { default as AppPasswordInput } from './Inputs/AppInputs/AppPasswordInput
 export { default as AppPhoneInput } from './Inputs/AppInputs/AppPhoneInput';
 export { default as AppSearchInput } from './Inputs/AppInputs/AppSearchInput';
 export { default as AppTextInput } from './Inputs/AppInputs/AppTextInput';
+/* Select fields */
+export { default as AppAutocomplete } from './Selects/Autocomplete/AppAutocomplete';
+export { default as AppSelect } from './Selects/BasicSelect/AppSelect';

--- a/src/theme/muiOutlinedInputStyles.js
+++ b/src/theme/muiOutlinedInputStyles.js
@@ -13,4 +13,21 @@ export const muiOutlinedInputStyles = {
       borderColor: customColors.outlineColor,
     },
   },
+  variants: [
+    {
+      props: { size: 'medium' },
+      style: {
+        '& .MuiInputBase-input': {
+          paddingTop: '11.5px',
+          paddingBottom: '11.5px',
+        },
+        '& .MuiInputLabel-root': {
+          transform: 'translate(14px, 11.5px) scale(1)',
+        },
+        '& .MuiInputLabel-shrink': {
+          transform: 'translate(14px, -9px) scale(0.75)',
+        },
+      },
+    },
+  ],
 };


### PR DESCRIPTION
1. Created a common AppSelect.jsx component
2. Created an AppAutocomplete.jsx select component to choose ingredients
3. Added "medium" size styles to the theme object
4. Centralized export of select fields to shared/index.js.